### PR TITLE
adding missing dependency to requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyppeteer==0.0.25
 tqdm==4.32.2
 urllib3==1.25.3
 websockets==8.0
+xmltodict==0.12.0


### PR DESCRIPTION
parsers.py file uses xmltodict library, which was not defined in requirements.txt file.